### PR TITLE
refactor(component): change @*Ref() to @*Ref

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3,6 +3,7 @@
 This document outlines the overall design for lit-kit
 
 ### Small and opinionated
+
 - Small: ~5kb Hello World ~6kb Todo App
 - there should only be one way to do things (unless there is an obvious exception)
 - Component and Custom Element are Separate. (You should be able to test component code without creating the custom element)
@@ -19,7 +20,7 @@ type ElementInstance<C, S> = HTMLElement & {
 
   // The actual instance of the component defined by the user
   componentInstance: ComponentInstance<C>;
-  
+
   // metadata used to create the element
   componentMetadata: Metadata<S>;
 
@@ -43,7 +44,7 @@ type ElementInstance<C, S> = HTMLElement & {
   }
 })
 class AppComponent implements OnInit {
-  constructor(@StateRef() private state: State<number>) {}
+  constructor(@StateRef private state: State<number>) {}
 
   onInit() {
     setInterval(() => {
@@ -102,7 +103,7 @@ function template(state: number, run: TemplateEvent): TemplateResult {
   template,
 })
 class AppComponent implements OnInit {
-  constructor(@StateRef() private state: State<number>) {}
+  constructor(@StateRef private state: State<number>) {}
 
   onInit() {
     setInterval(() => {

--- a/integration/hacker-news/src/app/app.component.ts
+++ b/integration/hacker-news/src/app/app.component.ts
@@ -113,8 +113,8 @@ export interface AppState {
 })
 export class AppComponent implements OnInit {
   constructor(
-    @StateRef() private state: State<AppState>,
-    @HackerNewsRef() private hackerNews: HackerNewsService
+    @StateRef private state: State<AppState>,
+    @HackerNewsRef private hackerNews: HackerNewsService
   ) {}
 
   onInit(): void {

--- a/integration/hacker-news/src/app/comments-drawer/comments-drawer.component.ts
+++ b/integration/hacker-news/src/app/comments-drawer/comments-drawer.component.ts
@@ -84,8 +84,8 @@ export class CommentsDrawerComponent implements OnPropChanges {
   @Prop() comments: HackerNewsItemComment[] = [];
 
   constructor(
-    @StateRef() private state: State<CommentsDrawerState>,
-    @ElRef() private elRef: HTMLElement
+    @StateRef private state: State<CommentsDrawerState>,
+    @ElRef private elRef: HTMLElement
   ) {}
 
   onPropChanges() {

--- a/integration/hacker-news/src/app/hacker-news.service.spec.ts
+++ b/integration/hacker-news/src/app/hacker-news.service.spec.ts
@@ -6,7 +6,7 @@ describe('HackerNewsService', () => {
     const injector = new Injector();
 
     class MyTestService {
-      constructor(@HackerNewsRef() public hackerNews: HackerNewsService) {}
+      constructor(@HackerNewsRef public hackerNews: HackerNewsService) {}
     }
 
     expect(injector.get(MyTestService).hackerNews).toBe(injector.get(HackerNewsService));

--- a/integration/hacker-news/src/app/hacker-news.service.ts
+++ b/integration/hacker-news/src/app/hacker-news.service.ts
@@ -26,10 +26,8 @@ export interface HackerNewsItemFull extends HackerNewsItem {
   comments: HackerNewsItemComment[];
 }
 
-export function HackerNewsRef() {
-  return function(c: any, p: string, i: number) {
-    Inject(HackerNewsService)(c, p, i);
-  };
+export function HackerNewsRef(c: any, p: string, i: number) {
+  Inject(HackerNewsService)(c, p, i);
 }
 
 @Service()

--- a/integration/hacker-news/src/app/news-card/news-card.component.ts
+++ b/integration/hacker-news/src/app/news-card/news-card.component.ts
@@ -65,7 +65,7 @@ export type NewsCardState = HackerNewsItem | null;
 export class NewsCardComponent implements OnPropChanges {
   @Prop() newsItem: NewsCardState = null;
 
-  constructor(@StateRef() private state: State<NewsCardState>) {}
+  constructor(@StateRef private state: State<NewsCardState>) {}
 
   onPropChanges() {
     this.state.setValue(this.newsItem);

--- a/integration/resistor-value/src/app/app.component.ts
+++ b/integration/resistor-value/src/app/app.component.ts
@@ -116,8 +116,8 @@ export interface AppState {
 })
 export class AppComponent implements OnInit {
   constructor(
-    @ResistorRef() private resistor: ResistorService,
-    @StateRef() private state: State<AppState>
+    @ResistorRef private resistor: ResistorService,
+    @StateRef private state: State<AppState>
   ) {}
 
   onInit() {

--- a/integration/resistor-value/src/app/resistor.component.ts
+++ b/integration/resistor-value/src/app/resistor.component.ts
@@ -86,7 +86,7 @@ import { ResistorBand } from './resistor.service';
 export class ResistorComponent implements OnPropChanges {
   @Prop() bands: ResistorBand[] = [];
 
-  constructor(@StateRef() private state: State<ResistorBand[]>) {}
+  constructor(@StateRef private state: State<ResistorBand[]>) {}
 
   onPropChanges() {
     this.state.setValue(this.bands);

--- a/integration/resistor-value/src/app/resistor.service.ts
+++ b/integration/resistor-value/src/app/resistor.service.ts
@@ -22,10 +22,8 @@ export interface ResistorBand {
   tolerance?: number;
 }
 
-export function ResistorRef() {
-  return function(c: any, p: string, i: number) {
-    Inject(ResistorService)(c, p, i);
-  };
+export function ResistorRef(c: any, p: string, i: number) {
+  Inject(ResistorService)(c, p, i);
 }
 
 @Service()

--- a/integration/resistor-value/src/app/select-band-color.component.ts
+++ b/integration/resistor-value/src/app/select-band-color.component.ts
@@ -59,8 +59,8 @@ export class SelectBandColorComponent implements OnPropChanges, SelectBandColorS
   @Prop() bands: ResistorBand[] = [];
 
   constructor(
-    @ElRef() private elRef: HTMLElement,
-    @StateRef() private state: State<SelectBandColorState>
+    @ElRef private elRef: HTMLElement,
+    @StateRef private state: State<SelectBandColorState>
   ) {}
 
   onPropChanges() {

--- a/integration/resistor-value/src/app/select-band-count.component.ts
+++ b/integration/resistor-value/src/app/select-band-count.component.ts
@@ -91,8 +91,8 @@ export class SelectBandCountComponent implements OnPropChanges, SelectBandCountS
   @Prop() selectedBands: ResistorBand[] = [];
 
   constructor(
-    @ElRef() private elRef: HTMLElement,
-    @StateRef() private state: State<SelectBandCountState>
+    @ElRef private elRef: HTMLElement,
+    @StateRef private state: State<SelectBandCountState>
   ) {}
 
   onPropChanges() {

--- a/integration/todo-app/src/app/app.component.ts
+++ b/integration/todo-app/src/app/app.component.ts
@@ -63,8 +63,8 @@ export interface AppState {
 })
 export class AppComponent implements OnInit {
   constructor(
-    @StateRef() private componentState: State<AppState>,
-    @TodoRef() private todo: TodoService
+    @StateRef private componentState: State<AppState>,
+    @TodoRef private todo: TodoService
   ) {}
 
   onInit(): void {

--- a/integration/todo-app/src/app/todo-card/todo-card.component.ts
+++ b/integration/todo-app/src/app/todo-card/todo-card.component.ts
@@ -63,10 +63,7 @@ export interface TodoCardState {
 export class TodoCardComponent implements OnPropChanges {
   @Prop() todo?: Todo;
 
-  constructor(
-    @StateRef() private state: State<TodoCardState>,
-    @ElRef() private elRef: HTMLElement
-  ) {}
+  constructor(@StateRef private state: State<TodoCardState>, @ElRef private elRef: HTMLElement) {}
 
   onPropChanges() {
     this.state.setValue({ todo: this.todo });

--- a/integration/todo-app/src/app/todo-form/todo-form.component.ts
+++ b/integration/todo-app/src/app/todo-form/todo-form.component.ts
@@ -41,10 +41,7 @@ export interface TodoFormState {
   }
 })
 export class TodoFormComponent {
-  constructor(
-    @StateRef() private state: State<TodoFormState>,
-    @ElRef() private elRef: HTMLElement
-  ) {}
+  constructor(@StateRef private state: State<TodoFormState>, @ElRef private elRef: HTMLElement) {}
 
   @Handle('FORM_SUBMIT') onFormSubmit(e: Event) {
     e.preventDefault();

--- a/integration/todo-app/src/app/todo.service.ts
+++ b/integration/todo-app/src/app/todo.service.ts
@@ -5,10 +5,8 @@ export class Todo {
   constructor(public readonly name: string, public readonly isComplete: boolean) {}
 }
 
-export function TodoRef() {
-  return function(c: any, p: string, i: number) {
-    Inject(TodoService)(c, p, i);
-  };
+export function TodoRef(c: any, p: string, i: number) {
+  Inject(TodoService)(c, p, i);
 }
 
 @Service()

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -84,7 +84,7 @@ class AppComponent {}
 ### Component State
 
 A component template can ONLY be updated by updating the component's state.
-A component's state can be accessed and updated via it's `State` instance which is available via `@StateRef()`
+A component's state can be accessed and updated via it's `State` instance which is available via `@StateRef`
 
 ```TS
 import { Component, StateRef, State, OnInit } from '@lit-kit/component';
@@ -98,7 +98,7 @@ import { html } from 'lit-html';
   }
 })
 class AppComponent implements OnInit {
-  constructor(@StateRef() private state: State<number>) {}
+  constructor(@StateRef private state: State<number>) {}
 
   onInit() {
     setInterval(() => {
@@ -127,7 +127,7 @@ import { html } from 'lit-html';
 class AppTitleComponent implements OnPropChanges {
   @Prop() title: string = '';
 
-  constructor(@StateRef() private state: State<string>) {}
+  constructor(@StateRef private state: State<string>) {}
 
   onPropChanges(_prop: string, _oldVal: any, newValue: any) {
     this.state.setValue(newVal);
@@ -158,7 +158,7 @@ import { html } from 'lit-html';
   }
 })
 class AppComponent {
-  constructor(@StateRef() private state: State<number>) {}
+  constructor(@StateRef private state: State<number>) {}
 
   @Handle('INCREMENT') onIncrement(_: Event) {
     this.state.setValue(this.state.value + 1);
@@ -173,7 +173,7 @@ class AppComponent {
 ### Dispatching Events
 
 To emit custom events from a component you will need to access the acutal custom element instance.
-This can be accessed via the `@ElRef()` decorator.
+This can be accessed via the `@ElRef` decorator.
 
 ```TS
 import { Component, StateRef, State, Handle, ElRef } from '@lit-kit/component';
@@ -194,8 +194,8 @@ import { html } from 'lit-html';
 })
 class AppComponent {
   constructor(
-    @StateRef() private state: State<number>,
-    @ElRef() private elRef: HTMLElement
+    @StateRef private state: State<number>,
+    @ElRef private elRef: HTMLElement
   ) {}
 
   @Handle('INCREMENT') onIncrement() {
@@ -231,7 +231,7 @@ interface AppState {
   template(state) { ... }
 })
 class AppComponent implements OnInit {
-  constructor(@StateRef() private state: State<AppState>) {}
+  constructor(@StateRef private state: State<AppState>) {}
 
   onInit() {
     this.state.setValue({ data: [], loading: true });

--- a/packages/component/src/lib/el-ref.spec.ts
+++ b/packages/component/src/lib/el-ref.spec.ts
@@ -11,7 +11,7 @@ describe('ElRef', () => {
     template: () => html``
   })
   class MyComponent {
-    constructor(@ElRef() public elRef: HTMLElement) {}
+    constructor(@ElRef public elRef: HTMLElement) {}
   }
 
   it('should provide an instance of the Custom Element', () => {

--- a/packages/component/src/lib/el-ref.ts
+++ b/packages/component/src/lib/el-ref.ts
@@ -2,8 +2,6 @@ import { ProviderToken, Inject } from '@lit-kit/di';
 
 export abstract class ElRefToken {}
 
-export function ElRef() {
-  return function(c: ProviderToken<any>, k: string, i: number) {
-    Inject(ElRefToken)(c, k, i);
-  };
+export function ElRef(c: ProviderToken<any>, k: string, i: number) {
+  Inject(ElRefToken)(c, k, i);
 }

--- a/packages/component/src/lib/state.ts
+++ b/packages/component/src/lib/state.ts
@@ -31,8 +31,6 @@ abstract class StateBase<T> {
 
 export class State<T> extends StateBase<T> {}
 
-export function StateRef() {
-  return function(c: ProviderToken<any>, k: string, i: number) {
-    Inject(State)(c, k, i);
-  };
+export function StateRef(c: ProviderToken<any>, k: string, i: number) {
+  Inject(State)(c, k, i);
 }

--- a/packages/schematics/src/component/files/component.ts.template
+++ b/packages/schematics/src/component/files/component.ts.template
@@ -20,5 +20,5 @@ export interface <%= classify(name) %>State {}
   }
 })
 export class <%= classify(name) %>Component {
-  constructor(@StateRef() _state: State<<%= classify(name) %>State>) {}
+  constructor(@StateRef _state: State<<%= classify(name) %>State>) {}
 }

--- a/packages/schematics/src/component/index_spec.ts
+++ b/packages/schematics/src/component/index_spec.ts
@@ -49,7 +49,7 @@ describe('new-component', () => {
     });
 
     it('should provide component state', () => {
-      expect(content.includes('constructor(@StateRef() _state: State<HelloWorldState>) {}')).toBe(
+      expect(content.includes('constructor(@StateRef _state: State<HelloWorldState>) {}')).toBe(
         true
       );
     });

--- a/packages/schematics/src/service/files/service.ts.template
+++ b/packages/schematics/src/service/files/service.ts.template
@@ -1,9 +1,7 @@
 import { Service, Inject } from '@lit-kit/di';
 
-export function <%= classify(name) %>Ref() {
-  return function(c: any, p: string, i: number) {
-    Inject(<%= classify(name) %>Service)(c, p, i);
-  }
+export function <%= classify(name) %>Ref()(c: any, p: string, i: number) {
+  Inject(<%= classify(name) %>Service)(c, p, i);
 }
 
 @Service()

--- a/packages/schematics/src/service/index_spec.ts
+++ b/packages/schematics/src/service/index_spec.ts
@@ -25,7 +25,10 @@ describe('new-service', () => {
     const content = file.toString();
 
     it('should create service ref decorator', () => {
-      expect(content.includes('export function HelloWorldRef() {')).toBe(true);
+      expect(
+        content.includes('export function HelloWorldRef()(c: any, p: string, i: number) {')
+      ).toBe(true);
+
       expect(content.includes('Inject(HelloWorldService)(c, p, i);')).toBe(true);
     });
 


### PR DESCRIPTION
This PR changes the format for Injectable refs from `@SomeRef()` to `@SomeRef`.
I think this is cleaner and shows that refs well never have arguments since they themselves are calling `Inject(SomeService`) under the hood. The argument against would be that if refs ever would require arguments it would have to be a breaking change.