### PR TITLE
WIP: feat(component): use global styles when not using shadowDom

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -83,7 +83,7 @@ class AppComponent {
   constructor(@Inject(AppService) app: AppService) {}
 }
 
-bootstrapApplication(); // create global root injector for global singletons
+bootstrapEnvironment(); // create global root injector for global singletons
 ```
 
 ### Template function should be pure functions and are able to be tested independently of the component

--- a/integration/hacker-news/src/main.ts
+++ b/integration/hacker-news/src/main.ts
@@ -1,8 +1,8 @@
 import './app/app.component';
 
-import { bootstrapApplication } from '@lit-kit/component';
+import { bootstrapEnvironment } from '@lit-kit/component';
 
-bootstrapApplication(); // only needed if you want singleton providers
+bootstrapEnvironment(); // only needed if you want singleton providers
 
 if (process.env.NODE_ENV === 'production') {
   navigator.serviceWorker.register('/service-worker.js').then(

--- a/integration/resistor-value/src/main.ts
+++ b/integration/resistor-value/src/main.ts
@@ -1,8 +1,8 @@
 import './app/app.component';
 
-import { bootstrapApplication } from '@lit-kit/component';
+import { bootstrapEnvironment } from '@lit-kit/component';
 
-bootstrapApplication(); // only needed if you want singleton providers
+bootstrapEnvironment(); // only needed if you want singleton providers
 
 if (process.env.NODE_ENV === 'production') {
   navigator.serviceWorker.register('/service-worker.js').then(

--- a/integration/resistor-value/webpack.config.js
+++ b/integration/resistor-value/webpack.config.js
@@ -21,7 +21,7 @@ if (process.env.NODE_ENV === 'production') {
   plugins.push(new GenerateSW());
   plugins.push(new CompressionPlugin());
   performance.hints = 'error';
-  performance.maxEntrypointSize = 27000;
+  performance.maxEntrypointSize = 28000;
 }
 
 module.exports = {

--- a/integration/router-test/src/main.ts
+++ b/integration/router-test/src/main.ts
@@ -1,5 +1,5 @@
 import './app/app.component';
 
-import { bootstrapApplication } from '@lit-kit/component';
+import { bootstrapEnvironment } from '@lit-kit/component';
 
-bootstrapApplication();
+bootstrapEnvironment();

--- a/integration/todo-app/src/app/app.component.ts
+++ b/integration/todo-app/src/app/app.component.ts
@@ -13,23 +13,23 @@ export interface AppState {
 @Component<AppState>({
   tag: 'app-root',
   initialState: { todos: [] },
-  useShadowDom: true,
+  useShadowDom: false,
   styles: [
     `
-      :host {
+      app-root {
         display: block;
       }
 
-      todo-form {
+      app-root todo-form {
         width: 100%;
         margin-bottom: 0.5rem;
       }
 
-      todo-card {
+      app-root todo-card {
         margin-bottom: 0.5rem;
       }
 
-      .placeholder {
+      app-root .placeholder {
         font-size: 1.5rem;
         text-align: center;
         padding: 1rem 0;

--- a/integration/todo-app/src/main.ts
+++ b/integration/todo-app/src/main.ts
@@ -1,5 +1,5 @@
 import './app/app.component';
 
-import { bootstrapApplication } from '@lit-kit/component';
+import { bootstrapEnvironment } from '@lit-kit/component';
 
-bootstrapApplication();
+bootstrapEnvironment();

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -24,7 +24,7 @@ bootstrapEnvironment()
 If you need to support older browsers (IE11) you will need to use the web components polyfills and enable shady css rendering.
 
 ```TS
-import { bootstrapEnvironment, Renderer } from '@lit-kit/component';
+import { bootstrapEnvironment } from '@lit-kit/component';
 import { withShadyRenderer } from '@lit-kit/component/lib/shady-renderer';
 
 bootstrapEnvironment([withShadyRenderer()]);
@@ -50,9 +50,9 @@ class AppComponent {}
 
 ### Component Styles
 
-When using ShadowDom, styles can either be placed in the "styles" array.
-Scoped styles CANNOT but used if not using shadow dom.
-If you want to use a css preprocessor look at things like webpacks scss-loader.
+Styles can either be placed in the "styles" array.
+Scoped styles are enabled when using shadow dom.
+If you want to use a css preprocessor look at things like webpack's scss-loader.
 
 ```TS
 import { Component } from '@lit-kit/component';

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -8,14 +8,15 @@ Create web components using [lit-html](https://lit-html.polymer-project.org/)
 npm i @lit-kit/component @lit-kit/di lit-html
 ```
 
-### Bootstrap Application
+### Bootstrap Environment
 
-If you plan on using lit-kit to create an application you will probably want to use services. To make sure you have singletons you need to bootstrap.
+If you plan on using lit-kit to create an application you will probably want to use services.
+To make sure you have singletons you need to bootstrap.
 
 ```TS
-import { bootstrapApplication } from '@lit-kit/component';
+import { bootstrapEnvironment } from '@lit-kit/component';
 
-bootstrapApplication()
+bootstrapEnvironment()
 ```
 
 ### Bootstrap Shady Application
@@ -23,10 +24,10 @@ bootstrapApplication()
 If you need to support older browsers (IE11) you will need to use the web components polyfills and enable shady css rendering.
 
 ```TS
-import { bootstrapApplication, Renderer } from '@lit-kit/component';
+import { bootstrapEnvironment, Renderer } from '@lit-kit/component';
 import { withShadyRenderer } from '@lit-kit/component/lib/shady-renderer';
 
-bootstrapApplication([withShadyRenderer()]);
+bootstrapEnvironment([withShadyRenderer()]);
 ```
 
 ### Component

--- a/packages/component/src/lib/environment.spec.ts
+++ b/packages/component/src/lib/environment.spec.ts
@@ -1,23 +1,23 @@
 import { Injector, Service, Inject } from '@lit-kit/di';
 
-import { bootstrapApplication, getApplicationRef, clearApplication } from './app';
+import { bootstrapEnvironment, getEnvironmentRef, clearEnvironment } from './environment';
 import { Component } from './component';
 import { html } from 'lit-html';
 import { createComponent } from './create-component';
 
-describe('app', () => {
+describe('environment', () => {
   afterEach(() => {
-    clearApplication();
+    clearEnvironment();
   });
 
   it('should be null by default', () => {
-    expect(getApplicationRef()).toBe(undefined);
+    expect(getEnvironmentRef()).toBe(undefined);
   });
 
   it('should create a global Injector instance', () => {
-    bootstrapApplication();
+    bootstrapEnvironment();
 
-    expect(getApplicationRef() instanceof Injector).toBe(true);
+    expect(getEnvironmentRef() instanceof Injector).toBe(true);
   });
 
   it('should use the root injector when creating components', () => {
@@ -35,10 +35,10 @@ describe('app', () => {
       constructor(@Inject(MyService) public myService: MyService) {}
     }
 
-    bootstrapApplication();
+    bootstrapEnvironment();
 
     const el = createComponent(MyComponent);
 
-    expect(el.componentInstance.myService).toBe(getApplicationRef()!.get(MyService));
+    expect(el.componentInstance.myService).toBe(getEnvironmentRef()!.get(MyService));
   });
 });

--- a/packages/component/src/lib/environment.ts
+++ b/packages/component/src/lib/environment.ts
@@ -2,16 +2,16 @@ import { Injector, Provider } from '@lit-kit/di';
 
 let ROOT_INJECTOR: Injector | undefined;
 
-export function bootstrapApplication(providers: Provider<any>[] = []): Injector {
+export function bootstrapEnvironment(providers: Provider<any>[] = []): Injector {
   ROOT_INJECTOR = new Injector({ providers });
 
   return ROOT_INJECTOR;
 }
 
-export function getApplicationRef(): Injector | undefined {
+export function getEnvironmentRef(): Injector | undefined {
   return ROOT_INJECTOR;
 }
 
-export function clearApplication(): void {
+export function clearEnvironment(): void {
   ROOT_INJECTOR = undefined;
 }

--- a/packages/component/src/public_api.ts
+++ b/packages/component/src/public_api.ts
@@ -1,4 +1,4 @@
-export { bootstrapApplication, clearApplication, getApplicationRef } from './lib/app';
+export { bootstrapEnvironment, clearEnvironment, getEnvironmentRef } from './lib/environment';
 export { ComponentInstance, Component, ElementInstance } from './lib/component';
 export { State, StateRef } from './lib/state';
 export { Prop } from './lib/prop';

--- a/packages/schematics/src/application/files/src/main.ts
+++ b/packages/schematics/src/application/files/src/main.ts
@@ -1,8 +1,8 @@
 import './app/app.component';
 
-import { bootstrapApplication } from '@lit-kit/component';
+import { bootstrapEnvironment } from '@lit-kit/component';
 
-bootstrapApplication(); // only needed if you want singleton providers
+bootstrapEnvironment(); // only needed if you want singleton providers
 
 if (process.env.NODE_ENV === 'production') {
   navigator.serviceWorker.register('/service-worker.js').then(


### PR DESCRIPTION
There could be reasons when you want to ship styles inline with a component when not using shadow dom. This would dynamically create a style tag in the head when a component type is first created and then remove it when all instances of a type are gone. From what I understand I should also be able to use constructable stylesheets for this as well. (if available)