### PR TITLE
feat(component): add dispatch method to template function

### DIFF
--- a/integration/todo-app/src/app/todo-card/todo-card.component.ts
+++ b/integration/todo-app/src/app/todo-card/todo-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, StateRef, State, ElRef, Handle, Prop, OnPropChanges } from '@lit-kit/component';
+import { Component, StateRef, State, Prop, OnPropChanges } from '@lit-kit/component';
 import { html } from 'lit-html';
 
 import { Todo } from '../todo.service';
@@ -43,7 +43,7 @@ export interface TodoCardState {
       }
     `
   ],
-  template(state, run) {
+  template(state, _, dispatch) {
     if (!state.todo) {
       return '';
     }
@@ -52,11 +52,11 @@ export interface TodoCardState {
       <div class="container ${state.todo.isComplete ? 'complete' : ''}">
         <span class="todo-name">${state.todo.name}</span>
 
-        <button @click=${run(state.todo.isComplete ? 'UNDO_COMPLETE' : 'COMPLETE_TODO')}>
+        <button @click=${dispatch(state.todo.isComplete ? 'undo_complete' : 'complete_todo')}>
           ${state.todo.isComplete ? 'UNDO' : 'COMPLETE'}
         </button>
 
-        <button @click=${run('REMOVE_TODO')}>REMOVE</button>
+        <button @click=${dispatch('remove_todo')}>REMOVE</button>
       </div>
     `;
   }
@@ -64,21 +64,9 @@ export interface TodoCardState {
 export class TodoCardComponent implements OnPropChanges {
   @Prop() todo?: Todo;
 
-  constructor(@StateRef private state: State<TodoCardState>, @ElRef private elRef: HTMLElement) {}
+  constructor(@StateRef private state: State<TodoCardState>) {}
 
   onPropChanges() {
     this.state.setValue({ todo: this.todo });
-  }
-
-  @Handle('REMOVE_TODO') onRemoveTodo(): void {
-    this.elRef.dispatchEvent(new CustomEvent('remove_todo'));
-  }
-
-  @Handle('COMPLETE_TODO') onCompleteTodo(): void {
-    this.elRef.dispatchEvent(new CustomEvent('complete_todo'));
-  }
-
-  @Handle('UNDO_COMPLETE') onUndoComplete(): void {
-    this.elRef.dispatchEvent(new CustomEvent('undo_complete'));
   }
 }

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -166,19 +166,22 @@ class AppComponent {
 
 ### Dispatching Events
 
-To emit custom events from a component you will need to access the acutal custom element instance.
-This can be accessed via the `@ElRef` decorator.
+There are two ways to dispatch events from a component.
+You can either:
+
+1. Use the dispatch method passed to your template function
+2. Inject the element reference with the @ElRef decorator
 
 ```TS
-import { Component, StateRef, State, Handle, ElRef } from '@lit-kit/component';
+import { Component, State, Handle, ElRef } from '@lit-kit/component';
 import { html } from 'lit-html';
 
 @Component<number>({
   tag: 'app-root',
   initialState: 0,
-  template(state, run) {
+  template(state, run, dispatch) {
     return html`
-      <button @click=${run('DECREMENT')}>Decrement</button>
+      <button @click=${dispatch('DECREMENT')}>Decrement</button>
 
       ${state}
 
@@ -187,21 +190,10 @@ import { html } from 'lit-html';
   }
 })
 class AppComponent {
-  constructor(
-    @StateRef private state: State<number>,
-    @ElRef private elRef: HTMLElement
-  ) {}
-
-  @Handle('INCREMENT') onIncrement() {
-    this.state.setValue(this.state.value + 1);
-
-    this.elRef.dispatchEvent(new CustomEvent('count_changed', { detail: this.state.value }));
-  }
+  constructor(@ElRef private elRef: HTMLElement) {}
 
   @Handle('DECREMENT') onDecrement() {
-    this.state.setValue(this.state.value - 1);
-
-    this.elRef.dispatchEvent(new CustomEvent('count_changed', { detail: this.state.value }));
+    this.elRef.dispatchEvent(new CustomEvent('INCREMENT'));
   }
 }
 ```

--- a/packages/component/README.md
+++ b/packages/component/README.md
@@ -173,7 +173,7 @@ You can either:
 2. Inject the element reference with the @ElRef decorator
 
 ```TS
-import { Component, State, Handle, ElRef } from '@lit-kit/component';
+import { Component, Handle, ElRef } from '@lit-kit/component';
 import { html } from 'lit-html';
 
 @Component<number>({

--- a/packages/component/src/lib/component.ts
+++ b/packages/component/src/lib/component.ts
@@ -77,17 +77,21 @@ function connectComponent<T>(
     }
   };
 
+  const dispatch = (eventName: string, detail: unknown) => () => {
+    el.dispatchEvent(new CustomEvent(eventName, { detail }));
+  };
+
   const componentTemplate =
     styleSheet || !config.useShadowDom
       ? (state: T) => html`
-          ${config.template(state, run)}
+          ${config.template(state, run, dispatch)}
         `
       : (state: T) => html`
           <style>
             ${styleString}
           </style>
 
-          ${config.template(state, run)}
+          ${config.template(state, run, dispatch)}
         `;
 
   const componentRender = (state: T) => {

--- a/packages/component/src/lib/metadata.ts
+++ b/packages/component/src/lib/metadata.ts
@@ -5,7 +5,8 @@ export type TemplateEvent = (event: string, ...args: unknown[]) => (e: Event) =>
 
 export type TemplateDef<T> = (
   state: T,
-  run: TemplateEvent
+  run: TemplateEvent,
+  dispatch: (eventName: string, detail?: any) => () => void
 ) => TemplateResult | string | HTMLElement | undefined | null;
 
 export interface ComponentConfig<T> {


### PR DESCRIPTION
Adds a dispatch function to the component template that immediately dispatches a custom event. This makes it easier when you have "dumb" components.
No need to hook up handlers and inject the element reference