### PR TITLE
feat(di): throw errors if non service is constructed as a singleton

### DIFF
--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -1,12 +1,13 @@
 import { injectableEl } from "./dom/injectable-el.js";
-import type { InjectableEl } from "./dom/injectable-el.js";
 import { INJECTOR, Injector } from "./injector.js";
+import { type InjectableMetadata } from "./metadata.js";
 import type { ConstructableToken, InjectionToken, Provider } from "./provider.js";
 
 export interface InjectableOpts {
   name?: string;
   providers?: Iterable<Provider<any>>;
   provideSelfAs?: InjectionToken<any>[];
+  service?: boolean;
 }
 
 export function injectable(opts?: InjectableOpts) {
@@ -14,6 +15,9 @@ export function injectable(opts?: InjectableOpts) {
     Base: T,
     ctx: ClassDecoratorContext,
   ): T {
+    const metadata: InjectableMetadata<T> = ctx.metadata;
+    metadata.service = opts?.service;
+
     const def = {
       [Base.name]: class extends Base {
         [INJECTOR]: Injector;

--- a/packages/di/src/lib/injector.test.ts
+++ b/packages/di/src/lib/injector.test.ts
@@ -357,7 +357,7 @@ it("should throw when a non-service token is injected as a singleton", () => {
 
   assert.throws(
     () => app.inject(NonService),
-    `Token NonService is marked as non-service and cannot be injected as a singleton. Please set singleton to false in the inject options.`,
+    `Token NonService is marked as non-service and cannot be injected as a singleton. Please use injectOnce.`,
   );
 });
 

--- a/packages/di/src/lib/injector.test.ts
+++ b/packages/di/src/lib/injector.test.ts
@@ -348,3 +348,40 @@ it("should respect ignoreParent option in injectOnce", () => {
   const childInstance = child.injectOnce(Service, { ignoreParent: true });
   assert.equal(childInstance.value, "child");
 });
+
+it("should throw when a non-service token is injected as a singleton", () => {
+  @injectable({ service: false })
+  class NonService {}
+
+  const app = new Injector();
+
+  assert.throws(
+    () => app.inject(NonService),
+    `Token NonService is marked as non-service and cannot be injected as a singleton. Please set singleton to false in the inject options.`,
+  );
+});
+
+it("should allow a non-service token to be injected with singleton: false", () => {
+  @injectable({ service: false })
+  class NonService {}
+
+  const app = new Injector();
+
+  const instance = app.inject(NonService, { singleton: false });
+
+  assert(instance instanceof NonService);
+});
+
+it("should allow multiple non-singleton instances of a non-service token", () => {
+  @injectable({ service: false })
+  class NonService {}
+
+  const app = new Injector();
+
+  const a = app.inject(NonService, { singleton: false });
+  const b = app.inject(NonService, { singleton: false });
+
+  assert(a instanceof NonService);
+  assert(b instanceof NonService);
+  assert.notEqual(a, b);
+});

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -76,7 +76,7 @@ export class Injector {
 
     if (metadata?.service === false && opts?.singleton !== false) {
       throw new Error(
-        `Token ${token instanceof StaticToken ? token.name : token.name} is marked as non-service and cannot be injected as a singleton. Please set singleton to false in the inject options.`,
+        `Token ${token.name} is marked as non-service and cannot be injected as a singleton. Please use injectOnce.`,
       );
     }
 

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -72,11 +72,18 @@ export class Injector {
     token: InjectionToken<T>,
     opts?: { ignoreParent?: boolean | undefined; singleton?: boolean | undefined },
   ): T {
+    const metadata = readMetadata<T>(token);
+
+    if (metadata?.service === false && opts?.singleton !== false) {
+      throw new Error(
+        `Token ${token instanceof StaticToken ? token.name : token.name} is marked as non-service and cannot be injected as a singleton. Please set singleton to false in the inject options.`,
+      );
+    }
+
     // check for a local instance
     if (opts?.singleton !== false && this.#instances.has(token)) {
       const instance = this.#instances.get(token);
 
-      const metadata = readMetadata<T>(token);
       const injector = readInjector(instance);
 
       if (metadata) {

--- a/packages/di/src/lib/metadata.ts
+++ b/packages/di/src/lib/metadata.ts
@@ -15,6 +15,7 @@ export interface LifecycleMethod<T> {
 }
 
 export interface InjectableMetadata<T> {
+  service?: boolean | undefined;
   onCreated?: LifecycleMethod<T>[] | undefined;
   onInjected?: LifecycleMethod<T>[] | undefined;
 }


### PR DESCRIPTION
This PR add the ability to restrict how injectable classes are constructed.
A class that is marked as NOT a service will not be able to be constructed with Injector.inject. I will be forced to use Injector.injectOnce.

```ts
@injectable({
  service: false
})
class MyThing {}

const injector = new Injector();

injector.inject(MyThing); // Error
injector.injectOnce(MyThing); // Success