### PR TITLE
feat(di): classes decorated with @injectable can only be constructed with Injector

### DIFF
--- a/packages/di/src/internal/symbols.ts
+++ b/packages/di/src/internal/symbols.ts
@@ -1,3 +1,3 @@
 export const INJECTOR: unique symbol = Symbol("JOIST_INJECTOR");
 
-export const INJECTABLE: unique symbol = Symbol("INJECTABLE");
+export const SENTINAL: unique symbol = Symbol("SENTINAL");

--- a/packages/di/src/internal/symbols.ts
+++ b/packages/di/src/internal/symbols.ts
@@ -1,0 +1,3 @@
+export const INJECTOR: unique symbol = Symbol("JOIST_INJECTOR");
+
+export const INJECTABLE: unique symbol = Symbol("INJECTABLE");

--- a/packages/di/src/lib.ts
+++ b/packages/di/src/lib.ts
@@ -1,4 +1,4 @@
-export { Injector } from "./lib/injector.js";
+export { Injector, type InjectorOpts } from "./lib/injector.js";
 export {
   type Provider,
   type ConstructableToken,

--- a/packages/di/src/lib/dom/dom-injector.ts
+++ b/packages/di/src/lib/dom/dom-injector.ts
@@ -1,6 +1,7 @@
+import { INJECTOR } from "../../internal/symbols.js";
 import { INJECTOR_CTX } from "../context/injector.js";
 import { ContextRequestEvent, type UnknownContext } from "../context/protocol.js";
-import { INJECTOR, Injector } from "../injector.js";
+import { Injector } from "../injector.js";
 
 /**
  * Special Injector that allows you to register an injector with a particular DOM element.

--- a/packages/di/src/lib/dom/injectable-el.ts
+++ b/packages/di/src/lib/dom/injectable-el.ts
@@ -1,6 +1,6 @@
+import { INJECTOR } from "../../internal/symbols.js";
 import { INJECTOR_CTX } from "../context/injector.js";
 import { ContextRequestEvent } from "../context/protocol.js";
-import { INJECTOR } from "../injector.js";
 import type { Injector } from "../injector.js";
 import { callLifecycle } from "../lifecycle.js";
 import type { InjectableMetadata } from "../metadata.js";

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -70,7 +70,10 @@ it("should inject a static token", () => {
     hello = inject(TOKEN);
   }
 
-  assert.strictEqual(new HelloWorld().hello(), "Hello World");
+  const injector = new Injector();
+  const instance = injector.inject(HelloWorld);
+
+  assert.strictEqual(instance.hello(), "Hello World");
 });
 
 it("should use the calling injector as parent", () => {
@@ -107,7 +110,10 @@ it("should allow you to inject all", () => {
     hello = injectAll(TOKEN);
   }
 
-  assert.deepEqual(new HelloWorld().hello(), ["Hello World"]);
+  const injector = new Injector();
+  const instance = injector.inject(HelloWorld);
+
+  assert.deepEqual(instance.hello(), ["Hello World", "Hello World"]);
 });
 
 it("should create non-singleton instances", () => {
@@ -119,6 +125,8 @@ it("should create non-singleton instances", () => {
     hello = inject(Hello, { singleton: false });
   }
 
-  const instance = new HelloWorld();
+  const injector = new Injector();
+  const instance = injector.inject(HelloWorld);
+
   assert.notEqual(instance.hello(), instance.hello());
 });

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -88,3 +88,20 @@ it("shoud throw error if attempting to to manually construct an injectable class
     new MyExtendedService();
   }, /Cannot construct an instance of MyService directly. Use the injector instead./);
 });
+
+it("should not pass the sentinal to the decorated class", () => {
+  const receivedArgs: unknown[][] = [];
+
+  @injectable()
+  class MyService {
+    constructor(...args: unknown[]) {
+      receivedArgs.push(args);
+    }
+  }
+
+  const injector = new Injector();
+
+  injector.inject(MyService);
+
+  assert.deepEqual(receivedArgs, [[]]);
+});

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -68,3 +68,23 @@ it("should provide itself for spefified tokens", () => {
 
   assert.equal(service.value(), service);
 });
+
+it("shoud throw error if attempting to to manually construct an injectable class", () => {
+  @injectable()
+  class MyService {}
+
+  assert.throws(() => {
+    new MyService();
+  }, /Cannot construct an instance of MyService directly. Use the injector instead./);
+});
+
+it("shoud throw error if attempting to to manually construct an injectable class extended from a base one", () => {
+  @injectable()
+  class MyService {}
+
+  class MyExtendedService extends MyService {}
+
+  assert.throws(() => {
+    new MyExtendedService();
+  }, /Cannot construct an instance of MyService directly. Use the injector instead./);
+});

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -18,21 +18,20 @@ it("should locally override a provider", () => {
     foo = inject(Foo);
   }
 
-  const el = new MyService();
+  const injector = new Injector();
+  const instance = injector.inject(MyService);
 
-  assert.instanceOf(el.foo(), Bar);
+  assert.instanceOf(instance.foo(), Bar);
 });
 
 it("should define an injector for a service instance", () => {
   @injectable()
-  class MyService {
-    constructor(public arg = "a") {}
-  }
+  class MyService {}
 
-  const instance = new MyService("b");
+  const injector = new Injector();
+  const instance = injector.inject(MyService);
 
-  assert.ok(readInjector(instance));
-  assert.ok(instance.arg === "b");
+  assert.instanceOf(readInjector(instance), Injector);
 });
 
 it("should inject the current service injectable instance", () => {
@@ -64,7 +63,8 @@ it("should provide itself for spefified tokens", () => {
     value = inject(TOKEN);
   }
 
-  const service = new MyService();
+  const injector = new Injector();
+  const service = injector.inject(MyService);
 
   assert.equal(service.value(), service);
 });

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -28,7 +28,7 @@ export function injectable(opts?: InjectableOpts) {
         [INJECTOR]: Injector;
 
         constructor(...args: any[]) {
-          // injectable classes should not be instantiated direction.
+          // injectable classes should not be instantiated directly.
           // HTMLElements MUST be instantiated by the browser.
           if (args[0] !== INJECTABLE && !isHTMLELementBase) {
             throw new Error(

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -32,7 +32,7 @@ export function injectable(opts?: InjectableOpts) {
           // HTMLElements MUST be instantiated by the browser.
           if (args[0] !== INJECTABLE && !isHTMLELementBase) {
             throw new Error(
-              `The constructor of an injectable class cannot be called directly. Please use the injector to create an instance of ${Base.name}.`,
+              `Cannot construct an instance of ${Base.name} directly. Use the injector instead.`,
             );
           }
 

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -1,4 +1,4 @@
-import { INJECTABLE, INJECTOR } from "../internal/symbols.js";
+import { SENTINAL, INJECTOR } from "../internal/symbols.js";
 import { injectableEl } from "./dom/injectable-el.js";
 import { Injector } from "./injector.js";
 import { type InjectableMetadata } from "./metadata.js";
@@ -28,15 +28,19 @@ export function injectable(opts?: InjectableOpts) {
         [INJECTOR]: Injector;
 
         constructor(...args: any[]) {
+          const potentialSentinal = args.at(-1);
+
           // injectable classes should not be instantiated directly.
-          // HTMLElements MUST be instantiated by the browser.
-          if (args[0] !== INJECTABLE && !isHTMLELementBase) {
+          // A sentinal value is passed as the last argument when the injector creates an instance of this class.
+          // If the sentinal value is not present, then we know this class is being instantiated directly and we can throw an error.
+          // HTMLElements MUST be instantiated by the browser and are allowed to be instantiated directly.
+          if (potentialSentinal !== SENTINAL && !isHTMLELementBase) {
             throw new Error(
               `Cannot construct an instance of ${Base.name} directly. Use the injector instead.`,
             );
           }
 
-          super(...args);
+          super(...args.slice(0, -1));
 
           this[INJECTOR] = new Injector(opts);
 

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -1,5 +1,5 @@
 import { injectableEl } from "./dom/injectable-el.js";
-import { INJECTOR, Injector } from "./injector.js";
+import { INJECTABLE, INJECTOR, Injector } from "./injector.js";
 import { type InjectableMetadata } from "./metadata.js";
 import type { ConstructableToken, InjectionToken, Provider } from "./provider.js";
 
@@ -18,11 +18,21 @@ export function injectable(opts?: InjectableOpts) {
     const metadata: InjectableMetadata<T> = ctx.metadata;
     metadata.service = opts?.service;
 
+    const isHTMLELementBase =
+      "HTMLElement" in globalThis &&
+      Object.prototype.isPrototypeOf.call(HTMLElement.prototype, Base.prototype);
+
     const def = {
       [Base.name]: class extends Base {
         [INJECTOR]: Injector;
 
         constructor(...args: any[]) {
+          if (args[0] !== INJECTABLE && !isHTMLELementBase) {
+            throw new Error(
+              `The constructor of an injectable class cannot be called directly. Please use the injector to create an instance of ${Base.name}.`,
+            );
+          }
+
           super(...args);
 
           this[INJECTOR] = new Injector(opts);
@@ -49,10 +59,9 @@ export function injectable(opts?: InjectableOpts) {
     }
 
     // Only apply custom element bootstrap logic if the decorated class is an HTMLElement
-    if ("HTMLElement" in globalThis) {
-      if (Object.prototype.isPrototypeOf.call(HTMLElement.prototype, Base.prototype)) {
-        return injectableEl(injectableBase, ctx);
-      }
+
+    if (isHTMLELementBase) {
+      return injectableEl(injectableBase, ctx);
     }
 
     return injectableBase;

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -40,7 +40,9 @@ export function injectable(opts?: InjectableOpts) {
             );
           }
 
-          super(...args.slice(0, -1));
+          const finalArgs = args.slice(0, -1); // remove sentinal from arguments list before passing to the decorated class
+
+          super(...finalArgs);
 
           this[INJECTOR] = new Injector(opts);
 

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -27,6 +27,8 @@ export function injectable(opts?: InjectableOpts) {
         [INJECTOR]: Injector;
 
         constructor(...args: any[]) {
+          // injectable classes should not be instantiated direction.
+          // HTMLElements MUST be instantiated by the browser.
           if (args[0] !== INJECTABLE && !isHTMLELementBase) {
             throw new Error(
               `The constructor of an injectable class cannot be called directly. Please use the injector to create an instance of ${Base.name}.`,

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -1,5 +1,6 @@
+import { INJECTABLE, INJECTOR } from "../internal/symbols.js";
 import { injectableEl } from "./dom/injectable-el.js";
-import { INJECTABLE, INJECTOR, Injector } from "./injector.js";
+import { Injector } from "./injector.js";
 import { type InjectableMetadata } from "./metadata.js";
 import type { ConstructableToken, InjectionToken, Provider } from "./provider.js";
 

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -98,7 +98,13 @@ export class Injector {
     // check for a provider definition
     if (provider) {
       if ("use" in provider) {
-        return this.#createAndCache<T>(token, () => new provider.use(INJECTABLE), createOpts);
+        const useMetadata = readMetadata<T>(provider.use);
+
+        return this.#createAndCache<T>(
+          token,
+          () => (useMetadata ? new provider.use(INJECTABLE) : new provider.use()),
+          createOpts,
+        );
       }
 
       if ("factory" in provider) {

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -1,3 +1,4 @@
+import { INJECTABLE } from "../internal/symbols.js";
 import { callLifecycle } from "./lifecycle.js";
 import { readInjector, readMetadata } from "./metadata.js";
 import {
@@ -13,9 +14,6 @@ export interface InjectorOpts {
   providers?: Iterable<Provider<any>>;
   parent?: Injector;
 }
-
-export const INJECTOR: unique symbol = Symbol("JOIST_INJECTOR");
-export const INJECTABLE: unique symbol = Symbol("INJECTABLE");
 
 export class ProviderMap extends Map<InjectionToken<any>, ProviderDef<any>> {}
 

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -133,7 +133,11 @@ export class Injector {
       return this.#createAndCache(token, token.factory, createOpts);
     }
 
-    return this.#createAndCache(token, () => new token(INJECTABLE), createOpts);
+    return this.#createAndCache(
+      token,
+      () => (metadata ? new token(INJECTABLE) : new token()),
+      createOpts,
+    );
   }
 
   clear(): void {

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -15,6 +15,7 @@ export interface InjectorOpts {
 }
 
 export const INJECTOR: unique symbol = Symbol("JOIST_INJECTOR");
+export const INJECTABLE: unique symbol = Symbol("INJECTABLE");
 
 export class ProviderMap extends Map<InjectionToken<any>, ProviderDef<any>> {}
 
@@ -99,7 +100,7 @@ export class Injector {
     // check for a provider definition
     if (provider) {
       if ("use" in provider) {
-        return this.#createAndCache<T>(token, () => new provider.use(), createOpts);
+        return this.#createAndCache<T>(token, () => new provider.use(INJECTABLE), createOpts);
       }
 
       if ("factory" in provider) {
@@ -128,7 +129,7 @@ export class Injector {
       return this.#createAndCache(token, token.factory, createOpts);
     }
 
-    return this.#createAndCache(token, () => new token(), createOpts);
+    return this.#createAndCache(token, () => new token(INJECTABLE), createOpts);
   }
 
   clear(): void {

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -1,4 +1,4 @@
-import { INJECTABLE } from "../internal/symbols.js";
+import { SENTINAL } from "../internal/symbols.js";
 import { callLifecycle } from "./lifecycle.js";
 import { readInjector, readMetadata } from "./metadata.js";
 import {
@@ -102,7 +102,7 @@ export class Injector {
 
         return this.#createAndCache<T>(
           token,
-          () => (useMetadata ? new provider.use(INJECTABLE) : new provider.use()),
+          () => (useMetadata ? new provider.use(SENTINAL) : new provider.use()),
           createOpts,
         );
       }
@@ -135,7 +135,7 @@ export class Injector {
 
     return this.#createAndCache(
       token,
-      () => (metadata ? new token(INJECTABLE) : new token()),
+      () => (metadata ? new token(SENTINAL) : new token()),
       createOpts,
     );
   }

--- a/packages/di/src/lib/metadata.ts
+++ b/packages/di/src/lib/metadata.ts
@@ -1,6 +1,7 @@
 (Symbol as any).metadata ??= Symbol("Symbol.metadata");
 
-import { INJECTOR, type Injector } from "./injector.js";
+import { INJECTOR } from "../internal/symbols.js";
+import { type Injector } from "./injector.js";
 import type { InjectionToken } from "./provider.js";
 
 export type LifecycleCallback = (i: Injector) => void;


### PR DESCRIPTION
This PR makes it so that classes decorated with @injectable are no longer able to be constructed manually and must be injected with an Injector. This can help with unintended "orphan" services that are not in an injection chain
