### PR TITLE
Allow injecting multiple providers for a single injector (closes #1083)

### DIFF
--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -57,9 +57,7 @@ export function injectable(opts?: InjectableOpts) {
 
             if (opts.provideSelfAs) {
               for (const token of opts.provideSelfAs) {
-                this[INJECTOR].providers.set(token, {
-                  factory: () => this,
-                });
+                this[INJECTOR].add(token, this);
               }
             }
           } else {

--- a/packages/di/src/lib/injector-cache.ts
+++ b/packages/di/src/lib/injector-cache.ts
@@ -1,0 +1,320 @@
+import { Injector } from "./injector.js";
+import { callLifecycle } from "./lifecycle.js";
+import { readInjector, readMetadata } from "./metadata.js";
+import {
+  StaticToken,
+  type InjectionToken,
+  type Provider,
+  type ProviderDef,
+  type ProviderFactory,
+} from "./provider.js";
+import { INJECTOR, SENTINAL } from "./symbols.js";
+
+/**
+ * Different types of items have different priorities.
+ * For example, if you provide a static token with a default
+ * factory alongside a custom factory in a `providers` section,
+ * it is expected that the custom factory will override the default
+ * by priority.
+ */
+enum InjectorCacheEntryPriority {
+  /** Raw instance with no provider */
+  VALUE,
+  /** Manually assigned providers */
+  PROVIDED,
+  /** Static Token's factory provider */
+  STATIC_TOKEN,
+  /** Constructable Token's new() provider */
+  CONSTRUCTABLE,
+}
+
+type InjectorCacheEntryParams<T> = {
+  priority: InjectorCacheEntryPriority;
+  token: InjectionToken<T>;
+  injector: Injector;
+  factory?: ProviderFactory<T> | undefined;
+  instance?: T | undefined;
+};
+
+export enum EntryFilter {
+  PROVIDERS = 0b0001,
+  INSTANCES = 0b0010,
+  NOT_PROVIDERS = 0b0100,
+  NOT_INSTANCES = 0b1000,
+  PROVIDERS_OR_INSTANCES = INSTANCES | PROVIDERS,
+  PROVIDERS_NOT_INSTANCES = PROVIDERS | NOT_INSTANCES,
+  INSTANCES_NOT_PROVIDERS = INSTANCES | NOT_PROVIDERS,
+}
+
+/**
+ * Stores a cached entry. an entry may have a factory, an instance, or both.
+ *
+ * Example of instance without factories:
+ *     Injector cannot have a factory, since the goal is to pull from the
+ *     highest parent before attempting to pull from a provider
+ *
+ * Example of provider without instance: uninstantiated providers
+ *
+ * @throws When instance and factory are both be undefined.
+ */
+export class InjectorCacheEntry<T> {
+  get factory() {
+    return this.#_factory;
+  }
+  get priority() {
+    return this.#_priority;
+  }
+  get instance() {
+    return this.#_instance;
+  }
+  [INJECTOR]: Injector;
+  #_instance?: T | undefined;
+  #_priority: InjectorCacheEntryPriority;
+  #_factory?: ProviderFactory<T> | undefined;
+  #token: InjectionToken<T>;
+
+  constructor(params: InjectorCacheEntryParams<T>) {
+    this.#token = params.token;
+    this.#_instance = params.instance;
+    this.#_priority = params.priority;
+    this.#_factory = params.factory;
+    this[INJECTOR] = params.injector;
+  }
+
+  /** Clears the cached value */
+  clear() {
+    this.#_instance = undefined;
+  }
+
+  /**
+   * Returns a cached entry or creates it if it doesn't exist
+   * @throws when factory is undefined but singleton is true
+   */
+  getOrInstantiate(opts?: { singleton?: boolean | undefined }): T {
+    if (this.#_instance === undefined || opts?.singleton === false) {
+      if (this.#_factory === undefined) {
+        throw new Error(`Provider not found for "${this.#token.name}"`);
+      }
+      if (opts?.singleton !== false) {
+        this.#_instance = this.#instantiate(this.#_factory, this.#token, opts);
+      } else {
+        return this.#_factory(this[INJECTOR]);
+      }
+    }
+    return this.#_instance;
+  }
+
+  #instantiate(
+    factory: ProviderFactory<T>,
+    token: InjectionToken<T>,
+    opts?: { singleton?: boolean | undefined },
+  ): T {
+    const instance = factory(this[INJECTOR]);
+
+    /**
+     * Only values that are objects are able to have associated injectors
+     */
+    const injector = readInjector(instance);
+
+    if (!injector) {
+      return instance;
+    }
+
+    if (injector !== this[INJECTOR]) {
+      /**
+       * set the this injector instance as a parent.
+       * This should ONLY happen in the injector is not self. This would cause an infinite loop.
+       * this means that each calling injector will be the parent of what it creates.
+       * this allows the created service to navigate up it's chain to find a root
+       */
+      injector.parent = this[INJECTOR];
+    }
+
+    /**
+     * the onInit lifecycle hook should be called after the parent is defined.
+     * this ensures that services are initialized when the chain is settled
+     * this is required since the parent is set after the instance is constructed
+     */
+    const metadata = readMetadata<T>(token);
+
+    if (metadata) {
+      callLifecycle(instance ?? this[INJECTOR], injector, metadata.onCreated);
+    }
+
+    return instance;
+  }
+}
+
+/**
+ * Stores multiple {@link InjectorCacheEntry}s.
+ */
+export class InjectorCacheRow<T> {
+  #caches = Array.from(
+    Object.values(InjectorCacheEntryPriority)
+      .filter((a) => typeof a === "number")
+      .map(() => new Array<InjectorCacheEntry<T>>()),
+  );
+  #token: InjectionToken<T>;
+  [INJECTOR]: Injector;
+
+  constructor(injector: Injector, token: InjectionToken<T>) {
+    this.#token = token;
+    this[INJECTOR] = injector;
+  }
+
+  /**
+   * Adds an entry to the cache row.
+   * @returns the entry added
+   */
+  add(
+    priority: InjectorCacheEntryPriority,
+    factory?: ProviderFactory<T> | undefined,
+    instance?: T | undefined,
+  ): InjectorCacheEntry<T> {
+    const entry = new InjectorCacheEntry({
+      injector: this[INJECTOR],
+      token: this.#token,
+      factory,
+      instance,
+      priority,
+    });
+    // Optimization: cache entries without instances or factories are unreachable
+    // so silently skip adding it in the first place. Might be better to throw
+    // instead but that changes the public interface slightly.
+    if (instance !== undefined || factory !== undefined) {
+      // ! is safe because #cache is guaranteed to have entries for all of InjectorCacheEntryPriority
+      this.#caches[priority]!.push(entry);
+    }
+    return entry;
+  }
+
+  clear() {
+    for (const entry of this) {
+      entry.clear();
+    }
+  }
+
+  *[Symbol.iterator](): Generator<InjectorCacheEntry<T>> {
+    for (const cache of this.#caches) {
+      for (const entry of cache) {
+        if (entry.factory !== undefined || entry.instance !== undefined) {
+          yield entry;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * This injector cache handles the storage of factories, caching, and instantiation of DI tokens on
+ * behalf of an Injector.
+ */
+export class InjectorCache {
+  #tokenCaches = new Map<InjectionToken<any>, InjectorCacheRow<any>>();
+  [INJECTOR]: Injector;
+
+  constructor(injector: Injector) {
+    this[INJECTOR] = injector;
+    const injectorRow = new InjectorCacheRow(injector, Injector);
+    injectorRow.add(InjectorCacheEntryPriority.VALUE, undefined, this[INJECTOR]);
+    this.#tokenCaches.set(Injector, injectorRow);
+  }
+
+  get<T>(token: InjectionToken<T>): InjectorCacheRow<T> | undefined {
+    return this.#tokenCaches.get(token);
+  }
+
+  /**
+   * Adds a token to the cache, returns an array of entries created.
+   * If the token has no factory, nothing will be created.
+   */
+  add<T>(token: InjectionToken<T>): [InjectorCacheEntry<T>];
+  /**
+   * Adds a value to the cache, returns an array of entries created.
+   * For values the entries returned will always be one.
+   */
+  add<T>(token: InjectionToken<T>, value: T): [InjectorCacheEntry<T>];
+  /**
+   * Adds a provider to the cache, returns an array of entries created.
+   * Two entries will be created if the provider token itself has a factory or constructor
+   */
+  add<T>(provider: Provider<T>): [InjectorCacheEntry<T>, InjectorCacheEntry<T>];
+  /**
+   * Adds a token or provider to the cache, returns an array of entries created.
+   */
+  add<T>(
+    tokenOrProvider: Provider<T> | InjectionToken<T>,
+    value?: T,
+  ): [] | [InjectorCacheEntry<T>] | [InjectorCacheEntry<T>, InjectorCacheEntry<T>];
+  add<T>(
+    tokenOrProvider: Provider<T> | InjectionToken<T>,
+    value?: T,
+  ): [] | [InjectorCacheEntry<T>] | [InjectorCacheEntry<T>, InjectorCacheEntry<T>] {
+    if (tokenOrProvider instanceof Array) {
+      const first = this.addProvider(tokenOrProvider);
+      const second = this.addToken(tokenOrProvider[0]);
+      return [first, second];
+    } else if (value !== undefined) {
+      return [this.addInstance(tokenOrProvider, value)];
+    } else {
+      const ret = this.addToken(tokenOrProvider);
+      return ret ? [ret] : [];
+    }
+  }
+
+  addProvider<T>(provider: Provider<T>): InjectorCacheEntry<T> {
+    let row = this.#tokenCaches.get(provider[0]);
+    if (row === undefined) {
+      row = new InjectorCacheRow(this[INJECTOR], provider[0]);
+      this.#tokenCaches.set(provider[0], row);
+    }
+    return row.add(InjectorCacheEntryPriority.PROVIDED, internalProviderDefToFactory(provider[1]));
+  }
+
+  addToken<T>(token: InjectionToken<T>): InjectorCacheEntry<T> {
+    let row = this.#tokenCaches.get(token);
+    if (row === undefined) {
+      row = new InjectorCacheRow(this[INJECTOR], token);
+      this.#tokenCaches.set(token, row);
+    }
+    if (token instanceof StaticToken) {
+      return row.add(InjectorCacheEntryPriority.STATIC_TOKEN, token.factory);
+    }
+    const metadata = readMetadata<T>(token);
+    return row.add(InjectorCacheEntryPriority.CONSTRUCTABLE, (i) =>
+      metadata ? new token({ sentinel: SENTINAL, injector: i }) : new token(),
+    );
+  }
+
+  addInstance<T>(token: InjectionToken<T>, value: T): InjectorCacheEntry<T> {
+    let row = this.#tokenCaches.get(token);
+    if (row === undefined) {
+      row = new InjectorCacheRow(this[INJECTOR], token);
+      this.#tokenCaches.set(token, row);
+    }
+    return row.add(InjectorCacheEntryPriority.VALUE, undefined, value);
+  }
+
+  /** Clears the whole cache, effectively returning it to its initial state */
+  clear(): void {
+    for (const row of this.#tokenCaches) {
+      row[1].clear();
+    }
+    this.#tokenCaches.clear();
+  }
+}
+
+function internalProviderDefToFactory<T>(provider: ProviderDef<T>): ProviderFactory<T> {
+  if ("use" in provider) {
+    const useMetadata = readMetadata<T>(provider.use);
+    return (i) =>
+      useMetadata ? new provider.use({ sentinel: SENTINAL, injector: i }) : new provider.use();
+  }
+  if ("factory" in provider) {
+    return provider.factory;
+  }
+  if ("value" in provider) {
+    return () => provider.value;
+  }
+  throw new Error(`Provider for Service is missing 'use', 'factory', or 'value'`);
+}

--- a/packages/di/src/lib/injector.test.ts
+++ b/packages/di/src/lib/injector.test.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 import { inject } from "./inject.js";
 import { injectable } from "./injectable.js";
 import { Injector } from "./injector.js";
-import { StaticToken } from "./provider.js";
+import { StaticToken, type Provider } from "./provider.js";
 
 it("should create a new instance of a single provider", () => {
   class A {}
@@ -161,13 +161,12 @@ it("should throw an error if provider is missing use, factory, and value", () =>
     }
   }
 
-  const injector = new Injector({
-    providers: [[Service, {} as any]],
-  });
-
   assert.throws(
-    () => injector.inject(Service),
-    "Provider for Service found but is missing either 'use', 'factory', or 'value'",
+    () =>
+      new Injector({
+        providers: [[Service, {} as any]],
+      }),
+    "Provider for Service is missing 'use', 'factory', or 'value'",
   );
 });
 
@@ -256,6 +255,69 @@ it("should allow you to get ALL available instances in a particular injector cha
   const res = injector.injectAll(TOKEN);
 
   assert.deepEqual(res, ["first", "second", "third", "fourth"]);
+});
+
+it("should allow getting multiple providers for the same token on the same injector", () => {
+  const TOKEN = new StaticToken<string>("TOKEN");
+
+  const injector = new Injector({
+    providers: [
+      [TOKEN, { factory: () => "first" }],
+      [TOKEN, { factory: () => "second" }],
+      [TOKEN, { factory: () => "third" }],
+      [TOKEN, { factory: () => "fourth" }],
+    ],
+  });
+
+  const res = injector.injectAll(TOKEN);
+
+  assert.deepEqual(res, ["first", "second", "third", "fourth"]);
+});
+
+// Including this test because it highlights a strange behavior, I think it's the least surprising though.
+// It's a direct consequence of the expectation that an override will not remove the original from the tree,
+// but just order it later.
+it("should inject the default factory for tokens when using multiple providers", () => {
+  const TOKEN = new StaticToken<string>("TOKEN", () => "default");
+
+  const injector = new Injector({
+    providers: [
+      [TOKEN, { factory: () => "first" }],
+      [TOKEN, { factory: () => "second" }],
+      [TOKEN, { factory: () => "third" }],
+      [TOKEN, { factory: () => "fourth" }],
+    ],
+  });
+
+  const res = injector.injectAll(TOKEN);
+
+  assert.deepEqual(res, [
+    "first",
+    "second",
+    "third",
+    "fourth",
+    "default",
+    "default",
+    "default",
+    "default",
+  ]);
+});
+
+// This test documents a difference from `inject`. When using `injectAll`, if you allow inserting providers to the injector on creation,
+// it gets very confusing *which* injectors to insert the provider on. Just the parent? All injectors? Just the child? We sidestep this
+// by explicitly only taking provided injectors when injecting all.
+it("should include not default injector for injectAll when no other injectors found", () => {
+  class A {}
+
+  @injectable()
+  class MyService {
+    a = inject(A);
+  }
+
+  const app = new Injector();
+  const instances = app.injectAll(MyService);
+
+  assert(instances.length === 0);
 });
 
 it("should respect skipParent option when injecting", () => {

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -1,21 +1,13 @@
-import { SENTINAL } from "./symbols.js";
 import { callLifecycle } from "./lifecycle.js";
-import { readInjector, readMetadata } from "./metadata.js";
-import {
-  type InjectionToken,
-  type Provider,
-  type ProviderDef,
-  type ProviderFactory,
-  StaticToken,
-} from "./provider.js";
+import { readMetadata } from "./metadata.js";
+import type { InjectionToken, Provider } from "./provider.js";
+import { EntryFilter, InjectorCache, InjectorCacheEntry } from "./injector-cache.js";
 
 export interface InjectorOpts {
   name?: string | undefined;
   providers?: Iterable<Provider<any>> | undefined;
   parent?: Injector | undefined;
 }
-
-export class ProviderMap extends Map<InjectionToken<any>, ProviderDef<any>> {}
 
 /**
  * Injectors create and store instances of services.
@@ -39,41 +31,65 @@ export class ProviderMap extends Map<InjectionToken<any>, ProviderDef<any>> {}
  */
 export class Injector {
   // keep track of instances. One Token can have one instance
-  #instances = new WeakMap<InjectionToken<any>, any>();
+  protected _cache = new InjectorCache(this);
 
   name?: string | undefined;
   parent?: Injector | undefined;
-  providers: ProviderMap;
 
   constructor(opts?: InjectorOpts) {
     this.name = opts?.name;
     this.parent = opts?.parent;
-    this.providers = new ProviderMap(opts?.providers);
-    this.providers.set(Injector, { factory: () => this });
+    for (const provider of opts?.providers ?? []) {
+      this._cache.add(provider);
+    }
   }
 
   injectAll<T>(
     token: InjectionToken<T>,
-    opts?: { ignoreParent?: boolean; singleton?: boolean },
-    collection: T[] = [],
+    opts?: {
+      ignoreParent?: boolean | undefined;
+      ignoreSelf?: boolean | undefined;
+      singleton?: boolean | undefined;
+    },
   ): T[] {
-    collection.push(this.inject<T>(token, { ignoreParent: true, singleton: opts?.singleton }));
+    const metadata = readMetadata<T>(token);
 
-    if (this.parent) {
-      return this.parent.injectAll<T>(token, opts, collection);
+    if (metadata?.service === false && opts?.singleton !== false) {
+      throw new Error(
+        `Token ${token.name} is marked as non-service and cannot be injected as a singleton. Please use create.`,
+      );
     }
 
-    return collection;
+    const ret: T[] = [];
+
+    // Check for providers or instantiated instances
+    const providerIter = this.#iter(token, opts);
+    let next = providerIter.next();
+    while (!next.done) {
+      ret.push(next.value.getOrInstantiate(opts));
+      next = providerIter.next();
+    }
+
+    if (metadata) {
+      for (const instance of ret) {
+        callLifecycle(instance ?? this, this, metadata.onInjected);
+      }
+    }
+    return ret;
   }
 
   create<T>(token: InjectionToken<T>, opts?: { ignoreParent?: boolean }): T {
     return this.inject<T>(token, { ignoreParent: opts?.ignoreParent, singleton: false });
   }
 
-  // resolves and retuns and instance of the requested service
+  // resolves and returns and instance of the requested service
   inject<T>(
     token: InjectionToken<T>,
-    opts?: { ignoreParent?: boolean | undefined; singleton?: boolean | undefined },
+    opts?: {
+      ignoreParent?: boolean | undefined;
+      ignoreSelf?: boolean | undefined;
+      singleton?: boolean | undefined;
+    },
   ): T {
     const metadata = readMetadata<T>(token);
 
@@ -83,116 +99,95 @@ export class Injector {
       );
     }
 
-    // check for a local instance
-    if (opts?.singleton !== false && this.#instances.has(token)) {
-      const instance = this.#instances.get(token);
-
-      const injector = readInjector(instance);
-
-      if (metadata) {
-        callLifecycle(instance, injector ?? this, metadata.onInjected);
-      }
-
-      return instance;
+    let instance: T;
+    // Check for providers or instantiated instances
+    const firstInstanceOrProvider = this.#iter(token, opts).next();
+    if (!firstInstanceOrProvider.done) {
+      instance = firstInstanceOrProvider.value.getOrInstantiate(opts);
+    } else {
+      // Otherwise add to top of tree
+      instance = firstInstanceOrProvider.value._cache.addToken(token).getOrInstantiate(opts);
     }
 
-    const provider = this.providers.get(token);
-    const createOpts = { singleton: opts?.singleton !== false };
-
-    // check for a provider definition
-    if (provider) {
-      if ("use" in provider) {
-        const useMetadata = readMetadata<T>(provider.use);
-
-        return this.#createAndCache<T>(
-          token,
-          (i) =>
-            useMetadata
-              ? new provider.use({ sentinel: SENTINAL, injector: i })
-              : new provider.use(),
-          createOpts,
-        );
-      }
-
-      if ("factory" in provider) {
-        return this.#createAndCache<T>(token, provider.factory, createOpts);
-      }
-
-      if ("value" in provider) {
-        return this.#createAndCache<T>(token, () => provider.value, createOpts);
-      }
-
-      throw new Error(
-        `Provider for ${token.name} found but is missing either 'use', 'factory', or 'value'`,
-      );
+    if (metadata) {
+      callLifecycle(instance ?? this, this, metadata.onInjected);
     }
-
-    // check for a parent and attempt to get there
-    if (this.parent && opts?.ignoreParent !== true) {
-      return this.parent.inject(token, opts);
-    }
-
-    if (token instanceof StaticToken) {
-      if (!token.factory) {
-        throw new Error(`Provider not found for "${token.name}"`);
-      }
-
-      return this.#createAndCache(token, token.factory, createOpts);
-    }
-
-    return this.#createAndCache(
-      token,
-      (i) => (metadata ? new token({ sentinel: SENTINAL, injector: i }) : new token()),
-      createOpts,
-    );
+    return instance;
   }
 
   clear(): void {
-    this.#instances = new WeakMap();
+    this._cache.clear();
   }
 
-  #createAndCache<T>(
+  /**
+   * Adds a token to the injector
+   */
+  add<T>(token: InjectionToken<T>): void;
+  /**
+   * Adds a value to the injector
+   */
+  add<T>(token: InjectionToken<T>, value: T): void;
+  /**
+   * Adds a provider to the injector
+   */
+  add<T>(provider: Provider<T>): void;
+  /**
+   * Adds a token or provider to the injector
+   */
+  add<T>(tokenOrProvider: Provider<T> | InjectionToken<T>, value?: T): void {
+    this._cache.add(tokenOrProvider, value);
+  }
+
+  /**
+   *
+   * @param token Injection token to iterate through
+   * @param opts.ignoreParent Skip checking any parents
+   * @param opts.ignoreSelf Skip checking self
+   * @yields {@link InjectorCacheEntry<T>} while iterating
+   * @returns `{done: true, value: Injector}` where `value` is the last {@link injector} visited when done iterating
+   */
+  *#iter<T>(
     token: InjectionToken<T>,
-    factory: ProviderFactory<T>,
-    opts: { singleton: boolean },
-  ): T {
-    const instance = factory(this);
-
-    if (opts.singleton !== false) {
-      this.#instances.set(token, instance);
+    opts?: { ignoreParent?: boolean | undefined; ignoreSelf?: boolean | undefined },
+  ): Generator<InjectorCacheEntry<T>, Injector> {
+    const providerTreeIter = iterInjectorTree(this, opts);
+    let next = providerTreeIter.next();
+    while (next.done !== true) {
+      const row = next.value._cache.get(token);
+      if (row !== undefined) {
+        for (const provider of row) {
+          yield provider;
+        }
+      }
+      next = providerTreeIter.next();
     }
-
-    /**
-     * Only values that are objects are able to have associated injectors
-     */
-    const injector = readInjector(instance);
-
-    if (!injector) {
-      return instance;
-    }
-
-    if (injector !== this) {
-      /**
-       * set the this injector instance as a parent.
-       * This should ONLY happen in the injector is not self. This would cause an infinite loop.
-       * this means that each calling injector will be the parent of what it creates.
-       * this allows the created service to navigate up it's chain to find a root
-       */
-      injector.parent = this;
-    }
-
-    /**
-     * the onInject and onInit lifecycle hook should be called after the parent is defined.
-     * this ensures that services are initialized when the chain is settled
-     * this is required since the parent is set after the instance is constructed
-     */
-    const metadata = readMetadata<T>(token);
-
-    if (metadata) {
-      callLifecycle(instance ?? this, injector, metadata.onCreated);
-      callLifecycle(instance ?? this, injector, metadata.onInjected);
-    }
-
-    return instance;
+    return next.value;
   }
+}
+
+function* iterInjectorTree(
+  injector: Injector,
+  opts?: { ignoreParent?: boolean | undefined; ignoreSelf?: boolean | undefined },
+) {
+  // Ignore self + parent = ignore all, immediately return
+  if (opts?.ignoreSelf === true && opts.ignoreParent === true) {
+    return injector;
+  }
+  // if ignore self, skip ahead, if there's no parent, return
+  if (opts?.ignoreSelf === true) {
+    if (injector.parent == undefined) {
+      return injector;
+    }
+    injector = injector.parent;
+  }
+  yield injector;
+  if (opts?.ignoreParent === true) {
+    return injector;
+  }
+  while (injector.parent !== undefined) {
+    injector = injector.parent;
+    yield injector;
+  }
+  // allow last injector to be retrievable after iterating
+  return injector;
 }


### PR DESCRIPTION
# Overview
Closes #1083, it is unfortunately more of a rewrite than I'm comfortable with, but I'll explain my thought process.

Support for `injectAll` was first added in [PR #1164](https://github.com/joist-framework/joist/pull/1164), however it lacked the ability to provide multiple providers under the same token for the same inject, e.g.:

```typescript
it("should allow getting multiple providers for the same token on the same injector", () => {
  const TOKEN = new StaticToken<string>("TOKEN");

  const injector = new Injector({
    providers: [
      [TOKEN, { factory: () => "first" }],
      [TOKEN, { factory: () => "second" }],
      [TOKEN, { factory: () => "third" }],
      [TOKEN, { factory: () => "fourth" }],
    ],
  });

  const res = injector.injectAll(TOKEN);

  assert.deepEqual(res, ["first", "second", "third", "fourth"]);
});
```

With this pull request, the above test case passes.

# Breaking changes

Support for multiple providers for the same token on the same instance required deep changes to the underlying implementation to keep behavior working as it has with minimal breaks. However, not all breaks were avoided. This adds three breaking changes to the interface (that I have caught and decided not to fix):

1. The `providers` property no longer exists on injectors. Providers offer a great interface for describing providers, but it is easier internally to convert everything directly to instances and factories. Therefore, provider information is not stored.
2. The error: `Provider for Service found but is missing either 'use', 'factory', or 'value'` was changed to
   `Provider for Service is missing 'use', 'factory', or 'value'`, and it now is thrown on injector construction instead of when it is accessed. I consider this an improvement as it alerts developers to improper usage of the API earlier on.
3. When using `injectAll`, the injector will not add an instance from its default factory (that is, a `StaticToken`'s factory or a `ConstructableToken`'s constructor) if no previous instances or providers have been found. Under the current logic (before this PR), what would happen is if a provider existed in a child, and not in a parent, an instance would be created in the parent and the returned length would be two. Now it would just be one, only returning the entry on the child, unless provided explicitly in the parent. This effectively means that `inject(A)` will return an instance of `A`, whereas `injectAll(A)` would return `[]`, unless `A` is explicitly provided. This is to sidestep the hard question of _which_ injectors one would expect to have added when injecting all, and how to determine whether or not one has already been provided by default previously. In general I think this is acceptable since most (all?) uses of `injectAll` don't need the convenience of automatically registering a new provider for classes and static tokens.

# Surprising outcomes

## Duplicated Factories

See the below test:

```typescript
it("should inject the default factory for tokens when using multiple providers", () => {
  const TOKEN = new StaticToken<string>("TOKEN", () => "default");

  const injector = new Injector({
    providers: [
      [TOKEN, { factory: () => "first" }],
      [TOKEN, { factory: () => "second" }],
      [TOKEN, { factory: () => "third" }],
      [TOKEN, { factory: () => "fourth" }],
    ],
  });

  const res = injector.injectAll(TOKEN);

  assert.deepEqual(res, [
    "first",
    "second",
    "third",
    "fourth",
    "default",
    "default",
    "default",
    "default",
  ]);
});
```

This is a little surprising, and I mentioned deduplicating this before, alternatively it may be better not to add the default at all when providing, that behavior in and of itself is a little surprising IMO. I'm not sure which is preferable. Adding deduplication logic shouldn't be too hard but it is more lines of code. I would propose removing the behavior that providing a token also provides it's default factory entirely, but it would be another breaking change:

```typescript
const TOKEN = new StaticToken<string>("TOKEN", () => "default");

const injector = new Injector({
  providers: [
    [TOKEN, { factory: () => "first" }],
    [TOKEN, { factory: () => "second" }],
    [TOKEN, { factory: () => "third" }],
    [TOKEN, { factory: () => "fourth" }],
    [TOKEN, { use: TOKEN}]
  ],
});

const res = injector.injectAll(TOKEN);

assert.deepEqual(res, ["first", "second", "third", "fourth", "default"]);
```

and

```typescript
const TOKEN = new StaticToken<string>("TOKEN", () => "default");

const injector = new Injector({
  providers: [
    [TOKEN, { factory: () => "first" }],
    [TOKEN, { factory: () => "second" }],
    [TOKEN, { factory: () => "third" }],
    [TOKEN, { factory: () => "fourth" }],
  ],
});

const res = injector.injectAll(TOKEN);

assert.deepEqual(res, ["first", "second", "third", "fourth"]);
```

We could make it more ergonomic and have `TOKEN` be a shorthand for `[TOKEN, {use: TOKEN}]`.

# Design

## Current

The current (before this PR) injection system relied on a map to cache instances for tokens. This limited the number of instances and providers for a token to one-per-instance. Multi injection was achieved through continuing to call up the parent injectors. This method was reliable and robust. Simply changing the cache to a map to an array of tokens was attempted, but had unforeseen consequences in the ordering of cache entries.

## Cache system

The proposed design instead adds a cache system for injectors. Each injector has a *cache*, a *cache* contains a map from tokens to *cache-rows*. Each *cache-row* contains a list of *cache-entries*, ordered by priority (so the ordering when using multiple overrides is maintained). A *cache-entry* contains a factory and cached instance if available, the associated token, it's priority, and the injector that owns the cache that the cache entry belongs to.
```typescript
export class InjectorCacheEntry<T> {
  get factory() {
    return this.#_factory;
  }
  get priority() {
    return this.#_priority;
  }
  get instance() {
    return this.#_instance;
  }
  [INJECTOR]: Injector;
  #_instance?: T | undefined;
  #_priority: InjectorCacheEntryPriority;
  #_factory?: ProviderFactory<T> | undefined;
  #token: InjectionToken<T>;
```

This additional information allows instantiation logic to be handled on the *cache-entry* instead of by the injector, this in turn allows objects other than the associated injector to handle instantiation. This seems like an anti-pattern, but it drives the core of the iterator-based injection system.

## Iterator system

The iterator based injector system trades robust simplicity for being highly flexible. Injectors now have an `#iter` private method, which allows them to iterate over all *cache-entries*. *Caches* are now exposed as protected members to allow this. While this does remove some safety by revealing internals of injectors to other injectors, it allows for highly customizable traversal through the injection hierarchy. The current implementation of `#iter` searches up the tree once, for each injector, the order is:

1. Directly injected values, such as injectors or provideSelfAs
2. Entries provided in the providers constructor option
3. Static Tokens
4. Constructable Tokens

This order ensures user provided overrides are returned before default constructors and static tokens. I suppose it could be 2 tiers instead of 4. 

This iterator driven approach means that inject and `injectAll` can have the same implementations, with the only difference being how far the iterator goes. In `inject`, we just return the first result from the iterator. In `injectAll`, we return all results. 

# Tradeoffs

## Priority system feels arbitrary

This was largely implemented to default implementations to the back of the results. If we implemented the changes in [Duplicated Factories](#duplicated-factories), we may be able to remove the ordering system of cache rows.

## Much more complex

The imperative design focused around iterators comes with a lot of added technical debt. While I tried to make it as understandable as I could, it is undeniably more complex and harder to reason about over the current system.

## Likely more resource intensive

I suspect memory and code size are both impacted negatively, performance is likely slightly slower but similar. I haven't ran any benchmarks though.

## Introduction of a protected member

the `_cache` member is protected, which is only enforceable in TypeScript and not transpiled JavaScript. Currently most of the code bases uses public members or members made private by `#`, this marks a departure from that norm.

# Benefits

## More customizable

This opens the door to more advanced features in the future, such as filtering out particular subclasses or allowing arbitrary skips or stopping points (not that this is necessarily advisable, I just think it's cool). An earlier version first traversed the tree looking for instantiated instances, and then again for uninstantiated providers, but it was unnecessary.

## Can walk the tree without injecting

This also might pave the way for #960 since the injector tree is now traversible. 

## Multiple providers with the same token can be provided to one injector

The original motivation behind this PR.

# Testing

Unit tests for injector.ts were expanded. injector-cache.ts has no test file because:

- It's more of an extension of the injector logic than something meant to be used independently.
- It requires an injector for construction, so we'd have to construct an injector and then reach in to the protected cache to test directly.
- What we're concerned with is whether the injector behaves correctly, the injector-cache just exists to support that.
- It already has 98% coverage because it is exercised via the injector tests.
- Many of the existing injector tests would become redundant, since the logic they is handled has moved almost entirely to the injector-cache.
