### PR TITLE
chore(di): Add error classes.

### DIFF
--- a/packages/di/src/lib/dom/dom-injector.ts
+++ b/packages/di/src/lib/dom/dom-injector.ts
@@ -2,6 +2,7 @@ import { INJECTOR } from "../symbols.js";
 import { INJECTOR_CTX } from "../context/injector.js";
 import { ContextRequestEvent, type UnknownContext } from "../context/protocol.js";
 import { Injector } from "../injector.js";
+import { AlreadyAttachedError } from "../errors.js";
 
 /**
  * Special Injector that allows you to register an injector with a particular DOM element.
@@ -16,7 +17,7 @@ export class DOMInjector extends Injector {
 
   attach(element: Document | HTMLElement): void {
     if (this.isAttached) {
-      throw new Error(
+      throw new AlreadyAttachedError(
         `This DOMInjector is already attached to ${this.#element}. Detach first before attaching again`,
       );
     }

--- a/packages/di/src/lib/errors.ts
+++ b/packages/di/src/lib/errors.ts
@@ -1,0 +1,47 @@
+export class DependencyInjectionError extends Error {
+  override name = "DependencyInjectionError";
+}
+
+export class InjectorError extends DependencyInjectionError {
+  override name = "InjectorError";
+}
+
+export class DOMInjectorError extends InjectorError {
+  override name = "DOMInjectorError";
+}
+
+export class InjectableError extends DependencyInjectionError {
+  override name = "InjectableError";
+}
+
+export class NoInjectorError extends InjectableError {
+  override name = "NoInjectorError";
+}
+
+export class InstantiatedDirectlyError extends InjectableError {
+  override name = "InstantiatedDirectlyError";
+}
+
+export class InjectableCreationFailedError extends InjectableError {
+  override name = "InjectableCreationFailedError";
+}
+
+export class AlreadyAttachedError extends DOMInjectorError {
+  override name = "AlreadyAttachedError";
+}
+
+export class InjectNonServiceError extends InjectorError {
+  override name = "InjectNonServiceError";
+}
+
+export class InjectionError extends InjectorError {
+  override name = "InjectionError";
+}
+
+export class ProviderMissingOptionsError extends InjectionError {
+  override name = "ProviderMissingOptionsError";
+}
+
+export class ProviderNotFoundError extends InjectionError {
+  override name = "ProviderNotFoundError";
+}

--- a/packages/di/src/lib/inject.test.ts
+++ b/packages/di/src/lib/inject.test.ts
@@ -4,26 +4,31 @@ import { inject, injectAll } from "./inject.js";
 import { injectable } from "./injectable.js";
 import { Injector } from "./injector.js";
 import { StaticToken } from "./provider.js";
+import { NoInjectorError, ProviderNotFoundError } from "./errors.js";
 
 it("should throw error if called in constructor", () => {
-  assert.throws(() => {
-    class FooService {
-      value = "1";
-    }
-
-    @injectable()
-    class BarService {
-      foo = inject(FooService);
-
-      constructor() {
-        this.foo();
+  assert.throws(
+    () => {
+      class FooService {
+        value = "1";
       }
-    }
 
-    const parent = new Injector();
+      @injectable()
+      class BarService {
+        foo = inject(FooService);
 
-    parent.inject(BarService);
-  }, "BarService is either not injectable or a service is being called in the constructor.");
+        constructor() {
+          this.foo();
+        }
+      }
+
+      const parent = new Injector();
+
+      parent.inject(BarService);
+    },
+    NoInjectorError,
+    /BarService/,
+  );
 });
 
 it("should throw error if static token is unavailable", () => {
@@ -33,7 +38,7 @@ it("should throw error if static token is unavailable", () => {
     const parent = new Injector();
 
     parent.inject(TOKEN);
-  }, 'Provider not found for "test"');
+  }, ProviderNotFoundError);
 });
 
 it("should use the calling injector as parent", () => {

--- a/packages/di/src/lib/inject.ts
+++ b/packages/di/src/lib/inject.ts
@@ -1,6 +1,7 @@
 import type { Injector } from "./injector.js";
 import { readInjector } from "./metadata.js";
 import type { InjectionToken } from "./provider.js";
+import { NoInjectorError } from "./errors.js";
 
 export type Injected<T> = () => T;
 
@@ -40,7 +41,7 @@ function internalInject<T extends object, R>(cb: (i: Injector) => R) {
     const injector = readInjector(this);
 
     if (injector === null) {
-      throw new Error(
+      throw new NoInjectorError(
         `${this.constructor.name} is either not injectable or a service is being called in the constructor. \n Either add the @injectable() to your class or use the @injected callback method.`,
       );
     }

--- a/packages/di/src/lib/injectable.test.ts
+++ b/packages/di/src/lib/injectable.test.ts
@@ -5,6 +5,7 @@ import { injectable } from "./injectable.js";
 import { Injector } from "./injector.js";
 import { readInjector } from "./metadata.js";
 import { StaticToken } from "./provider.js";
+import { InstantiatedDirectlyError } from "./errors.js";
 
 it("should locally override a provider", () => {
   class Foo {}
@@ -75,7 +76,7 @@ it("shoud throw error if attempting to to manually construct an injectable class
 
   assert.throws(() => {
     new MyService();
-  }, /Cannot construct an instance of MyService directly. Use the injector instead./);
+  }, InstantiatedDirectlyError);
 });
 
 it("shoud throw error if attempting to to manually construct an injectable class extended from a base one", () => {
@@ -86,7 +87,7 @@ it("shoud throw error if attempting to to manually construct an injectable class
 
   assert.throws(() => {
     new MyExtendedService();
-  }, /Cannot construct an instance of MyService directly. Use the injector instead./);
+  }, InstantiatedDirectlyError);
 });
 
 it("should not pass the sentinal to the decorated class", () => {

--- a/packages/di/src/lib/injectable.ts
+++ b/packages/di/src/lib/injectable.ts
@@ -3,6 +3,7 @@ import { injectableEl } from "./dom/injectable-el.js";
 import { Injector } from "./injector.js";
 import { type InjectableMetadata, isCreationContext } from "./metadata.js";
 import type { ConstructableToken, InjectionToken, Provider } from "./provider.js";
+import { InjectableCreationFailedError, InstantiatedDirectlyError } from "./errors.js";
 
 export interface InjectableOpts {
   name?: string;
@@ -36,7 +37,7 @@ export function injectable(opts?: InjectableOpts) {
           // If the sentinel is not present, then we know this class is being instantiated directly and we can throw an error.
           // HTMLElements MUST be instantiated by the browser and are allowed to be instantiated directly.
           if (!isFromInjector && !isHTMLELementBase) {
-            throw new Error(
+            throw new InstantiatedDirectlyError(
               `Cannot construct an instance of ${Base.name} directly. Use the injector instead.`,
             );
           }
@@ -67,7 +68,7 @@ export function injectable(opts?: InjectableOpts) {
     const injectableBase = def[Base.name];
 
     if (!injectableBase) {
-      throw new Error(`Failed to create injectable class for ${Base.name}`);
+      throw new InjectableCreationFailedError(`Failed to create injectable class for ${Base.name}`);
     }
 
     // Only apply custom element bootstrap logic if the decorated class is an HTMLElement

--- a/packages/di/src/lib/injector.test.ts
+++ b/packages/di/src/lib/injector.test.ts
@@ -4,6 +4,11 @@ import { inject } from "./inject.js";
 import { injectable } from "./injectable.js";
 import { Injector } from "./injector.js";
 import { StaticToken } from "./provider.js";
+import {
+  InjectNonServiceError,
+  ProviderMissingOptionsError,
+  ProviderNotFoundError,
+} from "./errors.js";
 
 it("should create a new instance of a single provider", () => {
   class A {}
@@ -165,10 +170,7 @@ it("should throw an error if provider is missing use, factory, and value", () =>
     providers: [[Service, {} as any]],
   });
 
-  assert.throws(
-    () => injector.inject(Service),
-    "Provider for Service found but is missing either 'use', 'factory', or 'value'",
-  );
+  assert.throws(() => injector.inject(Service), ProviderMissingOptionsError);
 });
 
 it("should pass factories and instance of the injector", async () => {
@@ -305,7 +307,7 @@ it("should handle StaticToken with null/undefined factory", () => {
   const TOKEN = new StaticToken<string | null>("test");
   const injector = new Injector();
 
-  assert.throws(() => injector.inject(TOKEN), 'Provider not found for "test"');
+  assert.throws(() => injector.inject(TOKEN), ProviderNotFoundError);
 });
 
 it("should handle StaticToken factory throwing errors", () => {
@@ -393,10 +395,7 @@ it("should throw when a non-service token is injected as a singleton", () => {
 
   const app = new Injector();
 
-  assert.throws(
-    () => app.inject(NonService),
-    `Token NonService is marked as non-service and cannot be injected as a singleton. Please use create.`,
-  );
+  assert.throws(() => app.inject(NonService), InjectNonServiceError);
 });
 
 it("should allow a non-service token to be injected with singleton: false", () => {

--- a/packages/di/src/lib/injector.ts
+++ b/packages/di/src/lib/injector.ts
@@ -8,6 +8,11 @@ import {
   type ProviderFactory,
   StaticToken,
 } from "./provider.js";
+import {
+  InjectNonServiceError,
+  ProviderMissingOptionsError,
+  ProviderNotFoundError,
+} from "./errors.js";
 
 export interface InjectorOpts {
   name?: string | undefined;
@@ -78,7 +83,7 @@ export class Injector {
     const metadata = readMetadata<T>(token);
 
     if (metadata?.service === false && opts?.singleton !== false) {
-      throw new Error(
+      throw new InjectNonServiceError(
         `Token ${token.name} is marked as non-service and cannot be injected as a singleton. Please use create.`,
       );
     }
@@ -122,7 +127,7 @@ export class Injector {
         return this.#createAndCache<T>(token, () => provider.value, createOpts);
       }
 
-      throw new Error(
+      throw new ProviderMissingOptionsError(
         `Provider for ${token.name} found but is missing either 'use', 'factory', or 'value'`,
       );
     }
@@ -134,7 +139,7 @@ export class Injector {
 
     if (token instanceof StaticToken) {
       if (!token.factory) {
-        throw new Error(`Provider not found for "${token.name}"`);
+        throw new ProviderNotFoundError(`Provider not found for "${token.name}"`);
       }
 
       return this.#createAndCache(token, token.factory, createOpts);


### PR DESCRIPTION
I'm sure we can bikeshed the names, but I think letting errors get caught in a way that doesn't depend on comparing messages is a good thing, since it allows developers (and maintainers) to catch errors in a way that won't break if messages change. Just threw this together when working on `optional`. Let me know what you think. I'm sure this could apply to the broader joist framework but I haven't familiarized myself with the whole framework.